### PR TITLE
feat: allow Folder specifies a parent Folder in db layer

### DIFF
--- a/app/schemas/com.amrdeveloper.linkhub.data.source.local.LinkRoomDatabase/6.json
+++ b/app/schemas/com.amrdeveloper.linkhub.data.source.local.LinkRoomDatabase/6.json
@@ -1,0 +1,162 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 6,
+    "identityHash": "77d1a074a345f4c278d5974a27ad5969",
+    "entities": [
+      {
+        "tableName": "link",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`title` TEXT NOT NULL, `subtitle` TEXT NOT NULL, `url` TEXT NOT NULL, `pinned` INTEGER NOT NULL, `folder_id` INTEGER NOT NULL, `click_count` INTEGER NOT NULL, `created_time` INTEGER NOT NULL DEFAULT 0, `updated_time` INTEGER NOT NULL DEFAULT 0, `is_updated` INTEGER NOT NULL DEFAULT 0, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subtitle",
+            "columnName": "subtitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPinned",
+            "columnName": "pinned",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "folderId",
+            "columnName": "folder_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "clickedCount",
+            "columnName": "click_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdTime",
+            "columnName": "created_time",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "lastUpdatedTime",
+            "columnName": "updated_time",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isUpdated",
+            "columnName": "is_updated",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_link_title",
+            "unique": true,
+            "columnNames": [
+              "title"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_link_title` ON `${TABLE_NAME}` (`title`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "folder",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `pinned` INTEGER NOT NULL, `click_count` INTEGER NOT NULL, `color_name` TEXT NOT NULL, `parent_id` INTEGER NOT NULL DEFAULT -1, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPinned",
+            "columnName": "pinned",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "clickedCount",
+            "columnName": "click_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "folderColor",
+            "columnName": "color_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentId",
+            "columnName": "parent_id",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "-1"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_folder_name",
+            "unique": true,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_folder_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '77d1a074a345f4c278d5974a27ad5969')"
+    ]
+  }
+}

--- a/app/src/androidTest/java/com/amrdeveloper/linkhub/data/source/local/FolderDaoTest.kt
+++ b/app/src/androidTest/java/com/amrdeveloper/linkhub/data/source/local/FolderDaoTest.kt
@@ -88,6 +88,20 @@ class FolderDaoTest {
     }
 
     @Test
+    fun read_sortedFolderListByParentId() = runBlockingTest {
+        val parentFolder = Folder("Parent", id = 1)
+        folderDao.insert(parentFolder)
+
+        val childFolder1 = Folder("Child1", id = 2, parentId = 1)
+        folderDao.insert(childFolder1)
+        val childFolder2 = Folder("Child2", id = 3, parentId = 1)
+        folderDao.insert(childFolder2)
+
+        val sortedList = folderDao.getSortedFolderListByParentId(1)
+        assertThat(sortedList).containsExactly(childFolder1, childFolder2)
+    }
+
+    @Test
     fun update_folderClickCount() = runBlockingTest {
         val folder = Folder("Word")
         folderDao.insert(folder)

--- a/app/src/main/java/com/amrdeveloper/linkhub/data/Folder.kt
+++ b/app/src/main/java/com/amrdeveloper/linkhub/data/Folder.kt
@@ -16,6 +16,7 @@ data class Folder(
     @ColumnInfo(name = "pinned") var isPinned: Boolean = false,
     @ColumnInfo(name = "click_count") var clickedCount: Int = 0,
     @ColumnInfo(name = "color_name") var folderColor: FolderColor = FolderColor.NONE,
+    @ColumnInfo(name = "parent_id", defaultValue = "-1") var parentId: Int = -1,
     @PrimaryKey(autoGenerate = true) val id: Int = 0,
 ) : Parcelable {
     override fun toString(): String = name

--- a/app/src/main/java/com/amrdeveloper/linkhub/data/source/FolderDataSource.kt
+++ b/app/src/main/java/com/amrdeveloper/linkhub/data/source/FolderDataSource.kt
@@ -16,6 +16,8 @@ interface FolderDataSource {
 
     suspend fun getSortedFolderList(): Result<List<Folder>>
 
+    suspend fun getSortedFolderListByParentId(parentId: Int): Result<List<Folder>>
+
     suspend fun getLimitedSortedFolderList(limit: Int): Result<List<Folder>>
 
     suspend fun getSortedFolderListByKeyword(keyword: String): Result<List<Folder>>

--- a/app/src/main/java/com/amrdeveloper/linkhub/data/source/FolderRepository.kt
+++ b/app/src/main/java/com/amrdeveloper/linkhub/data/source/FolderRepository.kt
@@ -28,6 +28,10 @@ class FolderRepository(private val dataSource: FolderDataSource) {
         return dataSource.getSortedFolderList()
     }
 
+    suspend fun getSortedFolderListByParentId(parentId: Int): Result<List<Folder>> {
+        return dataSource.getSortedFolderListByParentId(parentId)
+    }
+
     suspend fun getLimitedSortedFolderList(limit: Int): Result<List<Folder>> {
         return dataSource.getLimitedSortedFolderList(limit)
     }

--- a/app/src/main/java/com/amrdeveloper/linkhub/data/source/local/FolderDao.kt
+++ b/app/src/main/java/com/amrdeveloper/linkhub/data/source/local/FolderDao.kt
@@ -20,6 +20,9 @@ interface FolderDao : BaseDao<Folder> {
     @Query("SELECT * FROM folder ORDER BY pinned DESC, click_count DESC")
     suspend fun getSortedFolderList(): List<Folder>
 
+    @Query("SELECT * FROM folder WHERE parent_id = :parentId ORDER BY pinned DESC, click_count DESC")
+    suspend fun getSortedFolderListByParentId(parentId: Int): List<Folder>
+
     @Query("SELECT * FROM folder ORDER BY pinned DESC, click_count DESC LIMIT :limit")
     suspend fun getLimitedSortedFolderList(limit: Int): List<Folder>
 

--- a/app/src/main/java/com/amrdeveloper/linkhub/data/source/local/FolderLocalDataSource.kt
+++ b/app/src/main/java/com/amrdeveloper/linkhub/data/source/local/FolderLocalDataSource.kt
@@ -60,6 +60,16 @@ class FolderLocalDataSource internal constructor(
         }
     }
 
+    override suspend fun getSortedFolderListByParentId(parentId: Int): Result<List<Folder>> =
+        withContext(ioDispatcher) {
+            return@withContext try {
+                Result.success(folderDao.getSortedFolderListByParentId(parentId))
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+        }
+
+
     override suspend fun getLimitedSortedFolderList(limit: Int): Result<List<Folder>> =
         withContext(ioDispatcher) {
             return@withContext try {

--- a/app/src/main/java/com/amrdeveloper/linkhub/data/source/local/LinkRoomDatabase.kt
+++ b/app/src/main/java/com/amrdeveloper/linkhub/data/source/local/LinkRoomDatabase.kt
@@ -6,7 +6,7 @@ import com.amrdeveloper.linkhub.data.Folder
 import com.amrdeveloper.linkhub.data.Link
 
 const val DATABASE_NAME = "link_database"
-const val DATABASE_VERSION = 5
+const val DATABASE_VERSION = 6
 
 @Database(
     entities = [Link::class, Folder::class],
@@ -15,7 +15,8 @@ const val DATABASE_VERSION = 5
         AutoMigration(from = 1, to = 2),
         AutoMigration(from = 2, to = 3),
         AutoMigration(from = 3, to = 4),
-        AutoMigration(from = 4, to = 5)
+        AutoMigration(from = 4, to = 5),
+        AutoMigration(from = 5, to = 6)
     ],
     exportSchema = true,
 )


### PR DESCRIPTION
implement #71 in db layer

Add a `parent_id` field in folder table with a default value `-1` which indecades that it belongs to the root folder, keeping a consistency with link table.